### PR TITLE
HDFS support for PowerPC

### DIFF
--- a/gl/float.c
+++ b/gl/float.c
@@ -20,6 +20,12 @@
 /* Specification.  */
 #include <float.h>
 
+union gl_long_double_union
+  {
+    struct { double hi; double lo; } dd;
+    long double ld;
+  };
+
 #if (defined _ARCH_PPC || defined _POWER) && (defined _AIX || defined __linux__) && (LDBL_MANT_DIG == 106) && defined __GNUC__
 const union gl_long_double_union gl_LDBL_MAX =
   { { DBL_MAX, DBL_MAX / (double)134217728UL / (double)134217728UL } };


### PR DESCRIPTION
Defined the gl_long_double_union which needed in case of PowerPC.